### PR TITLE
SINGLE_ORDINALS to contain 'second' which was missing

### DIFF
--- a/lib/numerizer.rb
+++ b/lib/numerizer.rb
@@ -76,6 +76,7 @@ class Numerizer
 
   SINGLE_ORDINALS = [
     ['first', 1],
+    ['second', 2],
     ['third', 3],
     ['fourth', 4],
     ['fifth', 5],


### PR DESCRIPTION
SINGLE_ORDINALS to contain 'second' which was missing
