### PR TITLE
Avoid matching fraction false positives

### DIFF
--- a/lib/numerizer.rb
+++ b/lib/numerizer.rb
@@ -131,7 +131,7 @@ class Numerizer
     # handle fractions
     FRACTIONS.each do |tp|
       string.gsub!(/a #{tp[0]}(?=$|\W)/i, '<num>1/' + tp[1].to_s)
-      string.gsub!(/\s#{tp[0]}(?=$|\W)/i, '/' + tp[1].to_s)
+      string.gsub!(/(?<=\d)\s+#{tp[0]}(?=$|\W)/i, '/' + tp[1].to_s)
     end
 
     (DIRECT_ORDINALS + SINGLE_ORDINALS).each do |on|

--- a/test/test_numerizer.rb
+++ b/test/test_numerizer.rb
@@ -68,6 +68,11 @@ class NumerizerTest < Test::Unit::TestCase
     assert_equal "3/8", Numerizer.numerize("three eighths")
   end
 
+  def test_fraction_false_positives
+    assert_equal "this quarter", Numerizer.numerize("this quarter")
+    assert_equal "next half", Numerizer.numerize("next half")
+  end
+
   def test_fractional_addition
     assert_equal "1.25", Numerizer.numerize("one and a quarter")
     assert_equal "2.375", Numerizer.numerize("two and three eighths")


### PR DESCRIPTION
I'm adding support to Chronic for parsing financial quarters, such as "this quarter", "last quarter" etc. and I ran into this issue. Hence this fix.
