### PR TITLE
Added Support for Linux On Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: ruby
+arch:
+  - amd64
+  - ppc64le
 rvm:
   - 2.2


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/numerizer/builds/207360782
Please have a look.

Regards,
ujjwal
