### PR TITLE
Treat "an"s equal to "a"s

### DIFF
--- a/lib/providers/english_provider.rb
+++ b/lib/providers/english_provider.rb
@@ -107,7 +107,7 @@ class EnglishProvider < GenericProvider
 
   def preprocess(string, ignore)
     string.gsub!(/ +|([^\d])-([^\d])/, '\1 \2') # will mutilate hyphenated-words
-    string.gsub!(/\ba$/, '') && string.rstrip! # doesn't make sense for an 'a' at the end to be a 1
+    string.gsub!(/\ban?$/, '') && string.rstrip! # doesn't make sense for an 'a' or an 'an' at the end to be a 1
   end
 
   def numerize_numerals(string, ignore, bias)
@@ -121,9 +121,9 @@ class EnglishProvider < GenericProvider
     string.gsub!(/(^|\W)(#{single_nums})\s(#{dir_nums_ten_prefs})(?=$|\W)/i) {$1 << $2 << ' hundred ' << $3}
     string.gsub!(/(^|\W)(#{dir_single_nums})(?=$|\W)/i) { $1 << '<num>' << DIRECT_SINGLE_NUMS[$2].to_s} 
     if bias == :ordinal
-      string.gsub!(/(^|\W)\ba\b(?=$|\W)(?! (?:#{ALL_ORDINALS_REGEX}))/i, '\1<num>' + 1.to_s)
+      string.gsub!(/(^|\W)\ban?\b(?=$|\W)(?! (?:#{ALL_ORDINALS_REGEX}))/i, '\1<num>' + 1.to_s)
     else
-      string.gsub!(/(^|\W)\ba\b(?=$|\W)/i, '\1<num>' + 1.to_s)
+      string.gsub!(/(^|\W)\ban?\b(?=$|\W)/i, '\1<num>' + 1.to_s)
     end
 
     # ten, twenty, etc.
@@ -145,7 +145,7 @@ class EnglishProvider < GenericProvider
     end
     quarters = regexify(['quarter', 'quarters'], ignore: ignore)
 
-    string.gsub!(/a (#{fractionals})(?=$|\W)/i) {'<num>1/' << ALL_FRACTIONS[$1].to_s}
+    string.gsub!(/an? (#{fractionals})(?=$|\W)/i) {'<num>1/' << ALL_FRACTIONS[$1].to_s}
     # TODO : Find Noun Distinction for Quarter
     if bias == :fractional
       string.gsub!(/(^|\W)(#{fractionals})(?=$|\W)/i) {'/' << ALL_FRACTIONS[$2].to_s}

--- a/test/test_numerizer_en.rb
+++ b/test/test_numerizer_en.rb
@@ -71,6 +71,7 @@ class NumerizerTestEN < TestCase
     assert_equal "1/4", Numerizer.numerize("one quarter")
     assert_equal "1/4", Numerizer.numerize("a quarter")
     assert_equal "1/8", Numerizer.numerize("one eighth")
+    assert_equal "1/8", Numerizer.numerize("an eighth")
 
     assert_equal "3/4", Numerizer.numerize("three quarters")
     assert_equal "2/4", Numerizer.numerize("two fourths")
@@ -81,6 +82,7 @@ class NumerizerTestEN < TestCase
   def test_fractional_addition
     assert_equal "1.25", Numerizer.numerize("one and a quarter")
     assert_equal "2.375", Numerizer.numerize("two and three eighths")
+    assert_equal "2.125", Numerizer.numerize("two and an eighth")
     assert_equal "2.5", Numerizer.numerize("two and a half")
     assert_equal "3.5 hours", Numerizer.numerize("three and a half hours")
   end
@@ -101,7 +103,7 @@ class NumerizerTestEN < TestCase
     assert_equal '1/2', Numerizer.numerize('1/2')
     assert_equal '05/06', Numerizer.numerize('05/06')
     assert_equal "3.5 hours", Numerizer.numerize("three and a half hours")
-    assert_equal "1/2 an hour", Numerizer.numerize("half an hour")
+    assert_equal "1/2 1 hour", Numerizer.numerize("half an hour")
   end
 
   def test_ordinal_strings


### PR DESCRIPTION
This PR adds `n?` to all occurrences of "a" so that "an" is also processed equivalently.

Fixes #19.