### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,30 @@
+
+name: test
+
+on: [ push, pull_request ]
+
+jobs:
+
+  test:
+
+    if: " ! (contains(github.event.head_commit.message, 'skip ci') || contains(github.event.head_commit.message, 'ci skip'))"
+
+    name: ${{matrix.ruby}} on ${{matrix.os}}
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.2, jruby-9.3, truffleruby-21.2 ]
+        experimental: [ false ]
+      fail-fast: false
+    runs-on: ${{matrix.os}}
+    continue-on-error: ${{matrix.experimental}}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{matrix.ruby}}
+          bundler-cache: true
+      - run: bundle exec rake
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: ruby
-rvm:
-  - 2.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.11.1)
-    rake (13.0.1)
+    minitest (5.15.0)
+    rake (13.0.6)
 
 PLATFORMS
   ruby
@@ -18,4 +18,4 @@ DEPENDENCIES
   rake (~> 13)
 
 BUNDLED WITH
-   1.15.0
+   2.3.6

--- a/lib/numerizer.rb
+++ b/lib/numerizer.rb
@@ -12,6 +12,7 @@
 
 require 'numerizer/version'
 require 'providers/english_provider'
+require 'set'
 
 class Numerizer
 


### PR DESCRIPTION
This PR adds CI with GitHub Actions.

It upgrades the Gemfile.lock to use a modern bundler.  It also requires an explicit require for `set`, which was previously pulled in by `bundler`.

Everything runs green.